### PR TITLE
[ADJ] Nome especificado na string de conexão difere da DB

### DIFF
--- a/zirix-data/V3.sql
+++ b/zirix-data/V3.sql
@@ -1,5 +1,5 @@
-CREATE DATABASE IF NOT EXISTS `zirix`;
-USE `zirix`;
+CREATE DATABASE IF NOT EXISTS `clubz`;
+USE `clubz`;
 
 CREATE TABLE IF NOT EXISTS `phone_app_chat` (
   `id` int(11) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
O banco de dados estava sendo criado com o nome Zirix, enquanto a String de conexão, estava referenciada ao banco 'clubz'