### PR TITLE
[FIX] Destino da variação de fome e sede no comando god

### DIFF
--- a/zirix-data/resources/[vrp]/vrp_admin/skywalker.lua
+++ b/zirix-data/resources/[vrp]/vrp_admin/skywalker.lua
@@ -345,8 +345,8 @@ RegisterCommand('reviver',function(source,args,rawCommand)
 
                 vRPclient.killGod(nplayer)
 				vRPclient.setHealth(nplayer,400)
-				vRP.varyThirst(nplayer,-15)
-				vRP.varyHunger(nplayer,-15)
+				vRP.varyThirst(nuser_id,-15)
+				vRP.varyHunger(nuser_id,-15)
             end
 		else
 			PerformHttpRequest(config.Revive, function(err, text, headers) end, 'POST', json.encode({
@@ -376,8 +376,8 @@ RegisterCommand('reviver',function(source,args,rawCommand)
 
             vRPclient.killGod(source)
 			vRPclient.setHealth(source,400)
-			vRP.varyThirst(source,-100)
-			vRP.varyHunger(source,-100)
+			vRP.varyThirst(user_id,-100)
+			vRP.varyHunger(user_id,-100)
         end
     end
 end)


### PR DESCRIPTION
Quando a alteração da fome e sede, for client-side, deve-se usar o ped (source/nplayer/whatever)
Quando a alteração partir do server-side, deve-se usar a id da VRP